### PR TITLE
…Add DeviceFactory to be able to work with a single device without UPNP discovery. Fix DeviceLocator to work with IPv4 and IPv6 local network interfaces.

### DIFF
--- a/PS.FritzBox.API/Base/FritzTR64Client.cs
+++ b/PS.FritzBox.API/Base/FritzTR64Client.cs
@@ -95,7 +95,9 @@ namespace PS.FritzBox.API.Base
             if (parameter != null)
                 parameters.Parameters.AddRange(parameter);
 
-            XDocument soapResult = await client.InvokeAsync($"{this.ConnectionSettings.BaseUrl}{this.ControlUrl}", parameters);
+            var urlBuilder = new UriBuilder(this.ConnectionSettings.BaseUrl);
+            urlBuilder.Path = this.ControlUrl;
+            XDocument soapResult = await client.InvokeAsync(urlBuilder.Uri, parameters);
 
             this.ParseSoapFault(soapResult);
 

--- a/PS.FritzBox.API/DeviceFactory.cs
+++ b/PS.FritzBox.API/DeviceFactory.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Net;
+using System.Threading.Tasks;
+
+namespace PS.FritzBox.API
+{
+    /// <summary>
+    /// Factory that is able to create a single <see cref="FritzDevice"/> based on an ip.
+    /// </summary>
+    public class DeviceFactory
+    {
+        /// <summary>
+        /// Creates a single <see cref="FritzDevice"/>.
+        /// </summary>
+        /// <param name="address">The address the device can be found under.</param>
+        /// <returns>The ready-to-use device.</returns>
+        /// <exception cref="FritzDeviceException">Thrown if a device can not be created or if the data is incomplete.</exception>
+        public async Task<FritzDevice> CreateDeviceAsync(IPAddress address)
+        {
+            var locationBuilder = new UriBuilder("http", address.ToString(), _dataQueryPort);
+            var device = new FritzDevice(address, locationBuilder.Uri);
+            var tr64Reader = new Tr64DataReader();
+
+            var tr64Data = await tr64Reader.ReadDeviceInfoAsync(device);
+
+            device.ParseTR64Desc(tr64Data.Data);
+            return device;
+        }
+
+        private const int _dataQueryPort = 49000;
+    }
+}

--- a/PS.FritzBox.API/FritzDeviceException.cs
+++ b/PS.FritzBox.API/FritzDeviceException.cs
@@ -1,0 +1,24 @@
+﻿using System;
+
+namespace PS.FritzBox.API
+{
+    [Serializable]
+    public class FritzDeviceException : Exception
+    {
+        public FritzDeviceException()
+        {
+        }
+
+        public FritzDeviceException(string message) : base(message)
+        {
+        }
+
+        public FritzDeviceException(string message, Exception inner) : base(message, inner)
+        {
+        }
+
+        protected FritzDeviceException(
+          System.Runtime.Serialization.SerializationInfo info,
+          System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
+    }
+}

--- a/PS.FritzBox.API/SoapClient/SoapClient.cs
+++ b/PS.FritzBox.API/SoapClient/SoapClient.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using System.IO;
+using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
+using System.Xml;
 using System.Xml.Linq;
 
 namespace PS.FritzBox.API.SOAP
@@ -18,10 +20,10 @@ namespace PS.FritzBox.API.SOAP
         /// </summary>
         /// <param name="parameters">the request parameters</param>
         /// <returns>the result of the call</returns>
-        public async Task<XDocument> InvokeAsync(string url, SoapRequestParameters parameters)
+        public async Task<XDocument> InvokeAsync(Uri uri, SoapRequestParameters parameters)
         {
-            string envelope = this.CreateEnvelope(parameters);
-            return await this.ExecuteAsync(envelope, url, parameters);           
+            var envelope = this.CreateEnvelope(parameters);
+            return await this.ExecuteAsync(envelope, uri, parameters);           
         }
 
         /// <summary>
@@ -31,7 +33,6 @@ namespace PS.FritzBox.API.SOAP
         /// <returns></returns>
         private string CreateEnvelope(SoapRequestParameters parameters)
         {
-
             StringBuilder sb = new StringBuilder();
             sb.Append(@"<?xml version='1.0' encoding='UTF-8'?> 
                       <soap:Envelope xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
@@ -56,18 +57,18 @@ namespace PS.FritzBox.API.SOAP
         /// <param name="url">the soap url</param>
         /// <param name="parameters">the parameters</param>
         /// <returns></returns>
-        private async Task<XDocument> ExecuteAsync(string xmlSOAP, string url, SoapRequestParameters parameters)
+        private async Task<XDocument> ExecuteAsync(string xmlSOAP, Uri url, SoapRequestParameters parameters)
         {
             HttpClientHandler handler = new HttpClientHandler();            
             handler.ServerCertificateCustomValidationCallback = delegate { return true; };
             handler.Credentials = parameters.Credentials;
 
-            using (System.Net.Http.HttpClient client = new HttpClient(handler))
+            using (HttpClient client = new HttpClient(handler))
             {
                // client.Timeout = TimeSpan.FromMilliseconds(parameters.Timeout);
                 var request = new HttpRequestMessage()
                 {
-                    RequestUri = new Uri(url),
+                    RequestUri = url,
                     Method = HttpMethod.Post
                 };
                 

--- a/PS.FritzBox.API/Tr64DataReader.cs
+++ b/PS.FritzBox.API/Tr64DataReader.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.IO;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PS.FritzBox.API
+{
+    internal class Tr64DataReader
+    {
+        public async Task<Tr64Description> ReadDeviceInfoAsync(FritzDevice device)
+        {
+            var uri = CreateRequestUri(device);
+            var httpRequest = WebRequest.CreateHttp(uri);
+            httpRequest.Timeout = 10000;
+
+            try
+            {
+                using (var response = (HttpWebResponse)(await httpRequest.GetResponseAsync()))
+                {
+                    if (response.StatusCode == HttpStatusCode.OK)
+                    {
+                        using (var responseStream = response.GetResponseStream())
+                        using (var responseReader = new StreamReader(responseStream, Encoding.UTF8))
+                        {
+                            var data = await responseReader.ReadToEndAsync();
+                            return new Tr64Description(device, data);
+                        }
+                    }
+                    else
+                    {
+                        throw new FritzDeviceException($"Failed to get device info for device {device.Location.Host}. Response {response.StatusCode} - {response.StatusDescription}.");
+                    }
+                }
+            }
+            catch (WebException ex)
+            {
+                throw new FritzDeviceException($"Failed to get device info for device {device.Location.Host}.", ex);
+            }
+        }
+
+        private Uri CreateRequestUri(FritzDevice device)
+        {
+            var uriBuilder = new UriBuilder();
+            uriBuilder.Scheme = "http";
+            uriBuilder.Host = device.Location.Host;
+            uriBuilder.Port = device.Location.Port;
+            uriBuilder.Path = "tr64desc.xml";
+
+            return uriBuilder.Uri;
+        }
+    }
+}

--- a/PS.FritzBox.API/Tr64Description.cs
+++ b/PS.FritzBox.API/Tr64Description.cs
@@ -1,0 +1,33 @@
+﻿using System;
+
+namespace PS.FritzBox.API
+{
+    internal class Tr64Description
+    {
+        /// <summary>
+        /// Gets the device the description is valid for.
+        /// </summary>
+        public FritzDevice Device { get; }
+
+        /// <summary>
+        /// The raw data retrieved from the device.
+        /// </summary>
+        public string Data { get; }
+
+        public Tr64Description(FritzDevice device, string data)
+        {
+            if (device == null)
+            {
+                throw new ArgumentNullException(nameof(device));
+            }
+
+            if (string.IsNullOrWhiteSpace(data))
+            {
+                throw new ArgumentException("message", nameof(data));
+            }
+
+            Device = device;
+            Data = data;
+        }
+    }
+}

--- a/PS.FritzBox.API/UpnpBroadcast.cs
+++ b/PS.FritzBox.API/UpnpBroadcast.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Net;
+using System.Text;
+
+namespace PS.FritzBox.API
+{
+    /// <summary>
+    /// Contains all information that is necessary to perform a UPNP broadcast.
+    /// </summary>
+    internal class UpnpBroadcast
+    {
+        /// <summary>
+        /// Gets the content of the broadcast, the data that shall be sent.
+        /// </summary>
+        public byte[] Content { get; }
+
+        /// <summary>
+        /// Gets the number of bytes of <see cref="Content"/>.
+        /// </summary>
+        public int ContentLenght
+        {
+            get { return Content.Length; }
+        }
+
+        /// <summary>
+        /// Gets the ip that shall be used for the broadcast. This can either be an IPv4 or IPv6.
+        /// </summary>
+        public IPAddress IpAdress
+        {
+            get
+            {
+                return IpEndPoint.Address;
+            }
+        }
+
+        /// <summary>
+        /// Gets the whole <see cref="IPEndPoint"/> that shall be used for the broadcast.
+        /// </summary>
+        public IPEndPoint IpEndPoint { get; }
+
+        /// <summary>
+        /// Gets the port which shall be used for the broadcast.
+        /// </summary>
+        public int Port { get { return 1900; } }
+
+        private UpnpBroadcast(string host)
+        {
+            if (string.IsNullOrWhiteSpace(host))
+            {
+                throw new ArgumentException(nameof(host));
+            }
+
+            var ipAdress = IPAddress.Parse(host);
+            IpEndPoint = new IPEndPoint(ipAdress, Port);
+
+            StringBuilder sb = new StringBuilder();
+            sb.AppendLine("M-SEARCH * HTTP/1.1");
+            sb.AppendLine($"Host:239.255.255.250:1900");
+            sb.AppendLine("Man:\"ssdp:discover\"");
+            sb.AppendLine("ST:urn:schemas-upnp-org:device:InternetGatewayDevice:1");
+            sb.AppendLine("MX:3");
+
+            Content = Encoding.ASCII.GetBytes(sb.ToString());
+        }
+
+        /// <summary>
+        /// Creates a UPNP broadcast for an IPv4 network interface.
+        /// </summary>
+        public static UpnpBroadcast CreateIpV4Broadcast()
+        {
+            return new UpnpBroadcast("239.255.255.250");
+        }
+
+        /// <summary>
+        /// Creates a UPNP broadcast for an IPv6 network interface.
+        /// </summary>
+        public static UpnpBroadcast CreateIpV6Broadcast()
+        {
+            return new UpnpBroadcast("FF05::C");
+        }
+    }
+}


### PR DESCRIPTION
The problem with the DeviceLocator as reported in #12 was that IPv4 and IPv6 interfaces got mixed up. For example a IPv6 address was used as BroadcastAddress but the actual config was made for IPv4. This is fixed now.