### PR TITLE
Adds possibility to retreive userlist from Fritzbox at startup

### DIFF
--- a/PS.FritzBox.API.CMD/LanConfigSecurityHandler.cs
+++ b/PS.FritzBox.API.CMD/LanConfigSecurityHandler.cs
@@ -87,8 +87,8 @@ namespace PS.FritzBox.API.CMD
         {
             this.ClearOutputAction();
             this.PrintEntry();
-            var currentUser = await this._client.GetUserListAsync();
-            this.PrintObject(currentUser);
+            var userList = await this._client.GetUserListAsync();
+            this.PrintObject(userList);
         }
 
         private async Task GetInfo()

--- a/PS.FritzBox.API.CMD/LanConfigSecurityHandler.cs
+++ b/PS.FritzBox.API.CMD/LanConfigSecurityHandler.cs
@@ -22,8 +22,9 @@ namespace PS.FritzBox.API.CMD
                 this.PrintOutputAction($"LanConfigSecurityHandler{Environment.NewLine}########################");
                 this.PrintOutputAction("1 - GetAnonymousLogin");
                 this.PrintOutputAction("2 - GetCurrentUser");
-                this.PrintOutputAction("3 - GetInfo");
-                this.PrintOutputAction("4 - SetConfigPassword");
+                this.PrintOutputAction("3 - GetUserList");
+                this.PrintOutputAction("4 - GetInfo");
+                this.PrintOutputAction("5 - SetConfigPassword");
                 this.PrintOutputAction("r - Return");
 
                 input = this.GetInputFunc();
@@ -39,9 +40,12 @@ namespace PS.FritzBox.API.CMD
                             await this.GetCurrentUser();
                             break;
                         case "3":
-                            await this.GetInfo();
+                            await this.GetUserList();
                             break;
                         case "4":
+                            await this.GetInfo();
+                            break;
+                        case "5":
                             await this.SetConfigPassword();
                             break;
                         case "r":
@@ -76,6 +80,14 @@ namespace PS.FritzBox.API.CMD
             this.ClearOutputAction();
             this.PrintEntry();
             var currentUser = await this._client.GetCurrentUserAsync();
+            this.PrintObject(currentUser);
+        }
+
+        private async Task GetUserList()
+        {
+            this.ClearOutputAction();
+            this.PrintEntry();
+            var currentUser = await this._client.GetUserListAsync();
             this.PrintObject(currentUser);
         }
 

--- a/PS.FritzBox.API.CMD/Program.cs
+++ b/PS.FritzBox.API.CMD/Program.cs
@@ -42,7 +42,6 @@ namespace PS.FritzBox.API.CMD
 
                 FritzDevice selected = devices.Skip(deviceIndex).First();
                 Configure(selected);
-
                 do
                 {
                     Console.Clear();

--- a/PS.FritzBox.API/FritzBox/LANConfigSecurityClient.cs
+++ b/PS.FritzBox.API/FritzBox/LANConfigSecurityClient.cs
@@ -98,9 +98,9 @@ namespace PS.FritzBox.API
         }
 
         /// <summary>
-        /// Method to get the current user
+        /// Method to get the user list
         /// </summary>
-        /// <returns>the current user</returns>
+        /// <returns>the current userlist</returns>
         public async Task<LANConfigSecurityUserList> GetUserListAsync()
         {
             XDocument document = await this.InvokeAsync("X_AVM-DE_GetUserList", null);

--- a/PS.FritzBox.API/FritzBox/LANConfigSecurityClient.cs
+++ b/PS.FritzBox.API/FritzBox/LANConfigSecurityClient.cs
@@ -97,7 +97,19 @@ namespace PS.FritzBox.API
             return user;
         }
 
-        
+        /// <summary>
+        /// Method to get the current user
+        /// </summary>
+        /// <returns>the current user</returns>
+        public async Task<LANConfigSecurityUserList> GetUserListAsync()
+        {
+            XDocument document = await this.InvokeAsync("X_AVM-DE_GetUserList", null);
+            LANConfigSecurityUserList userList = new LANConfigSecurityUserList();
+            
+            userList.UserList = document.Descendants("NewX_AVM-DE_UserList").First().Value;
+            
+            return userList;
+        }
 
         /// <summary>
         /// Method to set the password for the current user

--- a/PS.FritzBox.API/FritzBox/LANConfigSecurityUserList.cs
+++ b/PS.FritzBox.API/FritzBox/LANConfigSecurityUserList.cs
@@ -1,0 +1,14 @@
+﻿namespace PS.FritzBox.API
+{
+    /// <summary>
+    /// class representing a userlist
+    /// </summary>
+    public class LANConfigSecurityUserList
+    {
+        /// <summary>
+        /// gets or sets the userlist
+        /// </summary>
+        public string UserList { get; set; }
+
+    }
+}

--- a/PS.FritzBox.API/FritzBox/LANConfigSecurityUserList.cs
+++ b/PS.FritzBox.API/FritzBox/LANConfigSecurityUserList.cs
@@ -1,4 +1,8 @@
-﻿namespace PS.FritzBox.API
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace PS.FritzBox.API
 {
     /// <summary>
     /// class representing a userlist


### PR DESCRIPTION
This little supplement to the library gives the possibility to retrieve the userlist from the Fritzbox to enable the selection through a combobox in a GUI or to give a preset of the last user in a console application (implemented in my branch developRoSchmi).
May be that this can be done in a better way, but I thought that perhaps you would like it.
Many thanks for your valuable code.
RoSchmi