### PR TITLE
added ax as WLANStandard for Wifi6

### DIFF
--- a/PS.FritzBox.API/FritzBox/LANDevice/WLANStandard.cs
+++ b/PS.FritzBox.API/FritzBox/LANDevice/WLANStandard.cs
@@ -27,6 +27,10 @@ namespace PS.FritzBox.API.LANDevice
         /// <summary>
         /// WLAN standard ac
         /// </summary>
-        ac
+        ac,
+        /// <summary>
+        /// WLAN standard ax
+        /// </summary>
+        ax
     }
 }


### PR DESCRIPTION
Added ax as a WLAN standard to support wifi6 routers otherwise the GetInfoAsync() from the WLANConfigurationClients will allways crash. 